### PR TITLE
Add cstring header include to globals.cc

### DIFF
--- a/globals.cc
+++ b/globals.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
## Summary
Added the `<cstring>` header include to globals.cc to support C string operations.

## Changes
- Added `#include <cstring>` to the include section of globals.cc

## Details
This header inclusion enables the use of C string manipulation functions (such as `strlen`, `strcpy`, `strcmp`, etc.) within the globals.cc file. This is a standard library header that provides C-style string handling utilities.

https://claude.ai/code/session_01DFgcbrRCjiEka1WbKUhPhD